### PR TITLE
Fix weird edge-case with k() function

### DIFF
--- a/PracticeScript.lua
+++ b/PracticeScript.lua
@@ -57,7 +57,7 @@ end
 function k()
 	invulnerable = false
 	for p in Players() do
-		p:damage(p.life+1, "fusion")
+		p:damage(2*p.life+1, "fusion")
 	end
 end
 


### PR DESCRIPTION
In some instances, K() will cause health to be halved instead of fully depleted. adding 2* before p.life for the function resolves this behavior.

(This was discussed with repo maintainer in marathonruns.net discord)